### PR TITLE
return by reference of the BigInteger after copy assignment (operator =).

### DIFF
--- a/ch5/BigInteger.cpp
+++ b/ch5/BigInteger.cpp
@@ -10,7 +10,7 @@ struct BigInteger {
   vector<int> s;
 
   BigInteger(long long num = 0) { *this = num; } // 构造函数
-  BigInteger operator = (long long num) { // 赋值运算符
+  BigInteger& operator = (long long num) { // 赋值运算符
     s.clear();
     do {
       s.push_back(num % BASE);
@@ -18,7 +18,7 @@ struct BigInteger {
     } while(num > 0);
     return *this;
   }
-  BigInteger operator = (const string& str) { // 赋值运算符
+  BigInteger& operator = (const string& str) { // 赋值运算符
     s.clear();
     int x, len = (str.length() - 1) / WIDTH + 1;
     for(int i = 0; i < len; i++) {


### PR DESCRIPTION
I think return by reference rather then by value after assignment (operator =) is more reasonable.
return a reference can make the `struct BigInteger` more similar to the built-in `int`.

consider the code following:
`int one; `
`BigInterger big_one;`
`(one = 1) = 2;`
`(big_one = 1) =2;`
after assignment, both `big_one` and `one` should be 2.
can do this by return reference after assignment.